### PR TITLE
Memperbaiki bug status UI tombol 'Claim Bounty'

### DIFF
--- a/apps/dashboard/src/app/bounty/[id]/page.tsx
+++ b/apps/dashboard/src/app/bounty/[id]/page.tsx
@@ -64,6 +64,10 @@ const BountyDetailPage: React.FC = () => {
 
   const { writeContract: payBountyWrite, isPending: isPaying } = useWriteContract();
   const { writeContract: cancelClaimByAdminWrite, isPending: isCancelling } = useWriteContract();
+  const { claimBounty, cancelClaim, isLoading: isClaiming } = useClaimBounty(() => {
+    refetchBountyData();
+    refetchClaimantsData();
+  });
 
   const handleCancelClaim = (claimantAddress: string) => {
     cancelClaimByAdminWrite({
@@ -393,6 +397,24 @@ const BountyDetailPage: React.FC = () => {
 
           {/* Action Buttons (removed Complete Bounty button) */}
           <div className="flex flex-wrap gap-4">
+            {currentBounty.status === 0 && !claimants?.includes(address as string) && (
+              <button
+                onClick={() => claimBounty(bountyId)}
+                disabled={isClaiming}
+                className="btn-cozy btn-cozy-primary"
+              >
+                {isClaiming ? 'Claiming...' : 'Claim Bounty'}
+              </button>
+            )}
+            {currentBounty.status === 0 && claimants?.includes(address as string) && (
+              <button
+                onClick={() => cancelClaim(bountyId)}
+                disabled={isClaiming}
+                className="btn-cozy btn-cozy-error"
+              >
+                {isClaiming ? 'Cancelling...' : 'Cancel Claim'}
+              </button>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Bug ini terjadi ketika Anda berhasil mengklaim hadiah, tetapi status tombol di UI gagal beralih ke 'Cancel'. Perbaikan ini memastikan bahwa setelah klaim berhasil, data hadiah diambil ulang, dan UI diperbarui untuk menampilkan tombol 'Cancel Claim'.