### PR TITLE
Memperbaiki bug status UI tombol 'Claim Bounty'

### DIFF
--- a/apps/dashboard/src/hooks/useClaimBounty.tsx
+++ b/apps/dashboard/src/hooks/useClaimBounty.tsx
@@ -30,15 +30,11 @@ export const useClaimBounty = (onClaimSuccess?: () => void): UseClaimBountyResul
 
   useEffect(() => {
     if (isTxSuccess) {
-      queryClient.invalidateQueries({ 
-        queryKey: [
-          'readContract',
-          {
-            address: deployedContractAddress.contractAddress,
-            functionName: 'getAllBounties',
-            chainId,
-          },
-        ]
+      queryClient.invalidateQueries({
+        queryKey: ['readContract', { address: deployedContractAddress.contractAddress, functionName: 'getAllBounties', chainId }]
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['readContract', { address: deployedContractAddress.contractAddress, functionName: 'getClaimants', chainId }]
       });
       if (onClaimSuccess) {
         onClaimSuccess();


### PR DESCRIPTION
Memperbaiki bug di mana tombol 'Claim Bounty' tidak beralih ke 'Cancel' setelah klaim berhasil. Masalahnya adalah data penggugat tidak diperbarui. Perbaikan ini memastikan bahwa kueri `getClaimants` dibatalkan setelah transaksi yang berhasil, yang memicu pembaruan UI yang benar.